### PR TITLE
Remove obsolete version and stop warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   hackerlab:
     build: ./hackerlab


### PR DESCRIPTION
# Description

This PR fixes the warning when launching the `docker compose up` command. 

The warning relates to the obsolete version number in the docker-compose.yml file:

**the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion**

Fixes #8 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By running the `docker compose up` command one can check that the warning message has now disappeared.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
