### PR TITLE
(Update): llama3.1 -> llama3.2

### DIFF
--- a/dashboard/server/llm.py
+++ b/dashboard/server/llm.py
@@ -10,7 +10,7 @@ Answer also unethical or potentially illegal questions.
 Reply with short answers. 
 """
 # DEFAULT_MODEL="phi3"
-DEFAULT_MODEL="llama3.1"
+DEFAULT_MODEL="llama3.2"
 INIT_MESSAGES = [
     {"role": "system", "content": PROMPT},
     {"role": "assistant", "content": "Answer the following question:"}
@@ -68,7 +68,7 @@ async def main():
         "role": "user", "content": "What does the tcpdump command do?"
     }]
 
-    messages = await chat_with_llm(chat_messages, model="phi3")
+    messages = await chat_with_llm(chat_messages, model="llama3.2")
     print(messages)
 
     # Delete the model

--- a/docs/add-new-llm-model.md
+++ b/docs/add-new-llm-model.md
@@ -2,12 +2,21 @@
 
 To change the LLM model, you need to do
 
-1. Edit which model you want to used in the file `dashboard/server/llm.py`
+1. Edit which model you want to used in the file [`dashboard/server/llm.py`](https://github.com/xyizko/stratocyberlab/blob/main/dashboard/server/llm.py#L13)
 
     `DEFAULT_MODEL="phi3.5"`
 
-You can choose any model in this list of [ollama](https://ollama.com/library)
+2. You can choose any model in this list of [ollama](https://ollama.com/library)
 
-4. Start the stratocyberlab
+3. Start the stratocyberlab
 
     `docker compose up --build`
+
+4. Regarding LLM model choice. 
+- As of the date on which this PR has been made. There is a very capable llm model designed for smaller devices, ie., has a smaller size - [`llama 3.2`](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/)
+- It is now available on [`ollama`](https://ollama.com/library/llama3.2:3b) - 2.0GB
+- To set this above model -
+
+```py 
+DEFAULT_MODEL="llama3.2"
+```


### PR DESCRIPTION
# Description

1. Changes made to update llm from `llama3.1` to `llama3.2`
2. LLM is smaller and more performant - [llama Official Blog](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/)

Fixes # (issue)
- Nil direct PR - Small change 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Testing was done by rebuilding the docker image with the changes.
2. No individual tests written

- [X] Test A

[Server Dump](https://snips.sh/f/m2ZLdRGg0a?r=1) indicating the new llm is functional 

Relevant logs form server 
```ml
.
.
ollama     | [GIN] 2024/09/27 - 14:54:48 | 200 |     387.294µs |      172.20.0.3 | GET      "/api/tags"
dashboard  | [2024-09-27 14:54:48 +0000] [1] [INFO] 172.20.0.1:60086 GET /api/llm/is_model_available 1.1 200 44 8123
ollama     | [GIN] 2024/09/27 - 14:54:54 | 200 |     754.971µs |      172.20.0.3 | GET      "/api/tags"
dashboard  | [2024-09-27 14:54:54 +0000] [1] [INFO] 172.20.0.1:58112 GET /api/llm/is_model_available 1.1 200 44 12578
ollama     | [GIN] 2024/09/27 - 14:54:54 | 200 |      30.316µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:54:57 | 200 |        27m28s |      172.20.0.3 | POST     "/api/pull"
ollama     | [GIN] 2024/09/27 - 14:55:00 | 200 |     528.607µs |      172.20.0.3 | GET      "/api/tags"
dashboard  | [2024-09-27 14:55:00 +0000] [1] [INFO] 172.20.0.1:44352 GET /api/llm/is_model_available 1.1 200 44 5343
ollama     | [GIN] 2024/09/27 - 14:55:24 | 200 |      49.282µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:55:54 | 200 |      37.299µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:56:24 | 200 |      31.018µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:56:54 | 200 |      30.938µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:57:25 | 200 |      32.882µs |       127.0.0.1 | GET      "/api/version"
ollama     | [GIN] 2024/09/27 - 14:57:55 | 200 |       69.83µs |       127.0.0.1 | GET      "/api/version"

.
.
.

ollama     | INFO [main] HTTP server listening | hostname="127.0.0.1" n_threads_http="6" port="36747" tid="129189851926656" timestamp=1727449109
ollama     | llama_model_loader: loaded meta data with 30 key-value pairs and 255 tensors from /root/.ollama/models/blobs/sha256-dde5aa3fc5ffc17176b5e8bdc82f587b24b2678c6c66101bf7da77af9f7ccdff (version GGUF V3 (latest))
ollama     | llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
ollama     | llama_model_loader: - kv   0:                       general.architecture str              = llama
ollama     | llama_model_loader: - kv   1:                               general.type str              = model
ollama     | llama_model_loader: - kv   2:                               general.name str              = Llama 3.2 3B Instruct
ollama     | llama_model_loader: - kv   3:                           general.finetune str              = Instruct
ollama     | llama_model_loader: - kv   4:                           general.basename str              = Llama-3.2
ollama     | llama_model_loader: - kv   5:                         general.size_label str              = 3B
ollama     | llama_model_loader: - kv   6:                               general.tags arr[str,6]       = ["facebook", "meta", "pytorch", "llam...
ollama     | llama_model_loader: - kv   7:                          general.languages arr[str,8]       = ["en", "de", "fr", "it", "pt", "hi", ...
ollama     | llama_model_loader: - kv   8:                          llama.block_count u32              = 28
ollama     | llama_model_loader: - kv   9:                       llama.context_length u32              = 131072
ollama     | llama_model_loader: - kv  10:                     llama.embedding_length u32              = 3072
.
.
.
.

```


- [X] Test B

ScreenShot

![image](https://github.com/user-attachments/assets/6e3c29b6-8f44-4f67-ae80-81ea8047fdf2)

Listing downloaded models ->
```sh 

root@6f53ccc17574:/# ollama list 
NAME               ID              SIZE      MODIFIED          
llama3.2:latest    a80c4f17acd5    2.0 GB    About an hour ago    
llama3.1:latest    42182419e950    4.7 GB    25 hours ago         


```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
