### PR TITLE
Add prototype implementation of live stream and class material google doc embedding into class detail view.

### DIFF
--- a/classes/class01/meta.json
+++ b/classes/class01/meta.json
@@ -1,5 +1,6 @@
 {
     "name": "Class 01 - Introduction",
     "id": "class-01",
-    "description": "The first class focuses on Introduction to security and basic networking. Please open the Google document provided to all registered students and follow the document."
+    "description": "The first class focuses on Introduction to security and basic networking. Please open the Google document provided to all registered students and follow the document.",
+    "googleDocUrl": "https://docs.google.com/document/d/1oF-yw2WMTKA9BsVOqsR59HSrD60gWWSUev23dEp9o14/"
 }

--- a/classes/class02/meta.json
+++ b/classes/class02/meta.json
@@ -1,5 +1,6 @@
 {
     "name": "Class 02 - Network Analysis",
     "id": "class-02",
-    "description": "The second class focuses on finding computers, scanning and other basic network analysis. Please open the Google document provided to all registered students and follow the document."
+    "description": "The second class focuses on finding computers, scanning and other basic network analysis. Please open the Google document provided to all registered students and follow the document.",
+    "googleDocUrl": "https://docs.google.com/document/d/1NZ2KRwgqDCO_GYcj4LMKpSFTEXBR3pXu9DyufZKHuYE"
 }

--- a/dashboard/client/src/App.svelte
+++ b/dashboard/client/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
   import Dashboard from "./Dashboard.svelte";
   import AssistantLLM from "./AssistantLLM.svelte";
+  import ClassDoc from "./ClassDoc.svelte";
   import LoadingOverlay from './LoadingOverlay.svelte';
   import SSH from "./Ssh.svelte";
   import {onMount} from "svelte";
@@ -77,8 +78,12 @@
       <div class="col-8">
         <Dashboard bind:chosenChallenge={chosenChallenge} bind:chosenClass={chosenClass} />
       </div>
-      <div class="col-4 {showSSH ? '' : 'h-75'}">
-        <AssistantLLM/>
+      <div class="col-4 {showSSH ? '' : (chosenClass !== undefined ? '' : 'h-75')}">
+        {#if chosenChallenge !== undefined}
+          <AssistantLLM/>
+        {:else if chosenClass !== undefined}
+          <ClassDoc bind:chosenClass={chosenClass} />
+        {/if}
       </div>
   </div>
 

--- a/dashboard/client/src/ClassDetail.svelte
+++ b/dashboard/client/src/ClassDetail.svelte
@@ -43,7 +43,11 @@
     </div>
 </div>
 <p class="pt-3 text-muted">{curClass.description}</p>
-
+<iframe width="100%" height="100%"
+        src="https://www.youtube-nocookie.com/embed/ye8lGXTcdCE?si=dBAWDNIhDH9yo--h"
+        title="CVUT Cybersecurity Live Stream" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 {#if curClass.dir}
 <div class="alert me-2 d-flex justify-content-between align-items-center {curClass.running ? 'alert-success' : 'alert-light'}" role="alert">
     <div class="d-flex align-items-center">

--- a/dashboard/client/src/ClassDoc.svelte
+++ b/dashboard/client/src/ClassDoc.svelte
@@ -1,0 +1,10 @@
+<script>
+  export let chosenClass;
+</script>
+
+<style>
+</style>
+
+<div class="mt-1 pt-2 position-relative h-100 w-100">
+  <iframe width="100%" height="100%" src="{chosenClass.googleDocUrl}"></iframe>
+</div>

--- a/dashboard/server/app.py
+++ b/dashboard/server/app.py
@@ -52,12 +52,13 @@ def init(parent_ch_dir='/challenges', parent_cl_dir='/classes'):
             class_data = json.load(f)
 
         dir = ""
+        googleDocUrl = class_data.get("googleDocUrl", "")
         if os.path.isfile(f"{cl_dir}/docker-compose.yml"):
             # set dir only if there is a docker-compose file
             dir = cl_dir
 
         id, name, desc = class_data["id"], class_data["name"], class_data["description"]
-        db.insert_class_data(id, name, desc, dir)
+        db.insert_class_data(id, name, desc, dir, googleDocUrl)
 
     file.touch()
     eprint("DB successfully initialised.")

--- a/dashboard/server/db.py
+++ b/dashboard/server/db.py
@@ -16,7 +16,8 @@ def init_db_tables():
                 id TEXT NOT NULL PRIMARY KEY,
                 name TEXT NOT NULL,
                 description TEXT NOT NULL,
-                dir TEXT NOT NULL
+                dir TEXT NOT NULL,
+                googleDocUrl TEXT NOT NULL
             );""")
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS challenges (
@@ -46,11 +47,11 @@ def init_db_tables():
     conn.commit()
     conn.close()
 
-def insert_class_data(id: str, name: str, desc: str, cl_dir: str):
+def insert_class_data(id: str, name: str, desc: str, cl_dir: str, googleDocUrl: str):
     conn = get_db()
     cursor = conn.cursor()
-    q = 'INSERT INTO classes (id, name, description, dir) VALUES (?, ?, ?, ?)'
-    cursor.execute(q, (id, name, desc, cl_dir))
+    q = 'INSERT INTO classes (id, name, description, dir, googleDocUrl) VALUES (?, ?, ?, ?, ?)'
+    cursor.execute(q, (id, name, desc, cl_dir, googleDocUrl))
     conn.commit()
 
 
@@ -58,7 +59,7 @@ def get_classes(only_with_compose: bool = False) -> List[Dict]:
     conn = get_db()
     cursor = conn.cursor()
     q = """
-    SELECT id, name, description, dir
+    SELECT id, name, description, dir, googleDocUrl
     FROM classes
     """
     if only_with_compose:


### PR DESCRIPTION
# Description

After multiple students have noted that they only have one screen to watch the live stream, read the class material google doc and work in a terminal, I provide a prototype implementation of a proposal on how to embed the live stream and class material google doc into the class detail views to allow for multiple uses of the same browser window at once.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Loading the app and checking that the individual class links load the matching google doc and live stream (which is the same live stream URL for all classes as of now).

# Checklist:

- [X] My code follows the style guidelines of this project (I hope)
- [X] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (There is no hard to understand new code)
- [x] I have made corresponding changes to the documentation (I don't believe a documentation is needed but I might be wrong.
- [X] My changes generate no new warnings
