### PR TITLE
[Feat] NotePad

### DIFF
--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "StratoCyberLab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "build": "rollup -c --bundleConfigAsCjs",
@@ -23,6 +23,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "bootstrap": "^5.3.2",
+    "file-saver": "^2.0.5",
     "marked": "^14.1.2",
     "sirv-cli": "^2.0.0",
     "socket.io-client": "^4.7.5",

--- a/dashboard/client/src/App.svelte
+++ b/dashboard/client/src/App.svelte
@@ -3,25 +3,28 @@
   import AssistantLLM from "./AssistantLLM.svelte";
   import LoadingOverlay from './LoadingOverlay.svelte';
   import SSH from "./Ssh.svelte";
-  import {onMount} from "svelte";
+  import { onMount } from "svelte";
   import ClassDoc from "./ClassDoc.svelte";
+  import NotePad from './NotePad.svelte'; // Import the new NotePad component
 
-  let showSSH = false
-  let sshInitialised = false
+  let showSSH = false;
+  let sshInitialised = false;
 
-  let sshHeight = 50
+  let sshHeight = 50;
   let isSshResizing = false;
-  $: dashboardHeight = showSSH ? 100 - sshHeight : 100
+  $: dashboardHeight = showSSH ? 100 - sshHeight : 100;
 
-  let widthVertical1st = 66
-  let isVerticalResizing = false
-  $: widthVertical2nd = 98 - widthVertical1st // 98 is tmp hack to fit in the vertical dragging line
-
+  let widthVertical1st = 66;
+  let isVerticalResizing = false;
+  $: widthVertical2nd = 98 - widthVertical1st; // 98 is tmp hack to fit in the vertical dragging line
 
   let chosenChallenge;
   let chosenClass;
 
   let resizeTerminalContentFunc;
+  let theme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  let notePadContent = localStorage.getItem('notePadContent') || 'Type notes here, and save to you editor';
+  let modalElement;
 
   onMount(() => {
     window.addEventListener("mousemove", resizeSSH);
@@ -29,47 +32,49 @@
 
     window.addEventListener("mousemove", resizeVertical);
     window.addEventListener("mouseup", stopVerticalResizing);
+
+    modalElement = document.getElementById('notePadModal'); // Get the modal element by its ID
   });
 
   function toggleShowSSH() {
-    sshInitialised = true
-    showSSH = !showSSH
+    sshInitialised = true;
+    showSSH = !showSSH;
   }
 
   function handleBrandClick() {
-    chosenChallenge = undefined
-    chosenClass = undefined
+    chosenChallenge = undefined;
+    chosenClass = undefined;
   }
 
   function startSshResizing() {
-    isSshResizing = true
+    isSshResizing = true;
   }
 
   function stopSshResizing() {
-    isSshResizing = false
+    isSshResizing = false;
   }
 
   function resizeSSH(e) {
     if (!isSshResizing) {
-      return
+      return;
     }
     const totalHeight = window.innerHeight;
     const newHeight = 100 - ((e.clientY / totalHeight) * 100);
     if (newHeight >= 10 && newHeight <= 90) {
       sshHeight = newHeight;
-      resizeTerminalContentFunc()
+      resizeTerminalContentFunc();
     }
   }
 
-  function startVerticalResizing(){
-    isVerticalResizing = true
+  function startVerticalResizing() {
+    isVerticalResizing = true;
   }
   function stopVerticalResizing() {
-    isVerticalResizing = false
+    isVerticalResizing = false;
   }
   function resizeVertical(e) {
     if (!isVerticalResizing) {
-      return
+      return;
     }
     const totalWidth = window.innerWidth;
     const newWidth = (e.clientX / totalWidth) * 100;
@@ -78,8 +83,16 @@
     }
   }
 
+  // Save note pad content to localStorage when it changes
+  $: localStorage.setItem('notePadContent', notePadContent);
 
+  // Function to open the modal
+  function openModal() {
+    modalElement.classList.add('show');
+    modalElement.style.display = 'block';
+  }
 </script>
+
 <style>
   .custom-rounded-button {
     border-radius: 20px 20px 0 0;
@@ -95,6 +108,7 @@
         <img src="/media/logo.png" alt="Logo" width="30" height="30" class="d-inline-block align-top">
         StratoCyberLab
       </a>
+      <button class="btn btn-secondary" on:click="{openModal}">Note Pad</button> <!-- New button to open the Note Pad modal -->
     </div>
   </nav>
 
@@ -137,3 +151,6 @@
   </div>
 </div>
 {/if}
+
+<!-- Modal -->
+<NotePad bind:notePadContent /> <!-- New NotePad component for the modal -->

--- a/dashboard/client/src/NotePad.svelte
+++ b/dashboard/client/src/NotePad.svelte
@@ -1,0 +1,101 @@
+<script>
+  import { onMount } from 'svelte';
+  import { saveAs } from 'file-saver'; // npm package for saving blobs
+
+  export let notePadContent = ''; // Default content for the note pad
+  let modalElement; // Variable to hold the modal DOM element
+
+  // Lifecycle function that runs when the component is mounted
+  onMount(() => {
+    modalElement = document.getElementById('notePadModal'); // Get the modal element by its ID
+  });
+
+  // Function to trap focus within the modal for better accessibility
+  function trapFocus(element) {
+    const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const modal = element.querySelector('.modal-content');
+    const firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
+    const focusableContent = modal.querySelectorAll(focusableElements);
+    const lastFocusableElement = focusableContent[focusableContent.length - 1];
+
+    // Event listener for keydown events, specifically for the Tab key
+    document.addEventListener('keydown', function(e) {
+      const isTabPressed = e.key === 'Tab';
+
+      if (!isTabPressed) {
+        return;
+      }
+
+      if (e.shiftKey) { // if shift key pressed for shift + tab combination
+        if (document.activeElement === firstFocusableElement) {
+          lastFocusableElement.focus(); // Move focus to the last focusable element
+          e.preventDefault();
+        }
+      } else { // if tab key is pressed
+        if (document.activeElement === lastFocusableElement) { // If focus reaches the last element, loop back to the first
+          firstFocusableElement.focus(); // Move focus to the first focusable element
+          e.preventDefault();
+        }
+      }
+    });
+
+    firstFocusableElement.focus(); // Focus on the first focusable element when the modal opens
+  }
+
+  // Function to open the modal
+  function openModal() {
+    modalElement.classList.add('show'); // Add 'show' class to display the modal
+    modalElement.style.display = 'block'; // Ensure the modal is visible
+    trapFocus(modalElement); // Trap focus within the modal for accessibility
+  }
+
+  // Function to close the modal
+  function closeModal() {
+    modalElement.classList.remove('show'); // Remove 'show' class to hide the modal
+    modalElement.style.display = 'none'; // Ensure the modal is hidden
+  }
+
+  // Function to save the note pad content to a text file
+  function saveToFile() {
+    const blob = new Blob([notePadContent], { type: "text/plain;charset=utf-8" }); // Create a Blob from the note pad content
+    saveAs(blob, "note_pad.txt"); // Use FileSaver.js to save the Blob as a text file
+  }
+</script>
+
+<style>
+  /* Styles for the modal when it is shown */
+  .modal.show {
+    display: block;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent background */
+  }
+
+  /* Styles for the modal content */
+  .modal-content {
+    border: 2px solid #000; /* Black border */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5); /* Shadow */
+  }
+
+  /* Styles for the modal header and footer */
+  .modal-header, .modal-footer {
+    border-color: #000; /* Black border for header and footer */
+  }
+</style>
+
+<!-- Modal structure -->
+<div id="notePadModal" class="modal fade" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Note Pad</h5>
+        <button type="button" class="btn-close" on:click="{closeModal}"></button> <!-- Close button -->
+      </div>
+      <div class="modal-body">
+        <textarea class="form-control" rows="10" bind:value={notePadContent}></textarea> <!-- Textarea for note pad content -->
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" on:click="{closeModal}">Close</button> <!-- Close button -->
+        <button type="button" class="btn btn-primary" on:click="{saveToFile}">Save to File</button> <!-- Save button -->
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Description

Implementation of storing notes feature as a _Note Pad Function_ with :
1. Persistence of notes across views 
2. Ability to save the notes as a text file

Fixes # (issue)

#14 

## Type of change

1. Bumped semantic versioning 
2. Added a separate component as a `NotePad.svelte`
3. Notepad is a modal since there is absence of any space for another side bar
4. Ability to store notes on disk, done via [`file-saver`](https://www.npmjs.com/package/file-saver)

### Video Demo 

https://github.com/user-attachments/assets/02c5aba3-c0ee-4844-99c7-7c76801d05f7

Demo Env 

```js
                          ./+o+-       codespace@codespaces-289191
                  yyyyy- -yyyyyy+      OS: Ubuntu 20.04 focal
               ://+//////-yyyyyyo      Kernel: x86_64 Linux 6.5.0-1025-azure
           .++ .:/++++++/-.+sss/`      Uptime: 36m
         .:++o:  /++++++++/:--:/-      Packages: 638
        o:+o+:++.`..```.-/oo+++++/     Shell: fish 3.1.0
       .:+o:+o/.          `+sssoo+/    Disk: 54G / 105G (54%)
  .++/+:+oo+o:`             /sssooo.   CPU: AMD EPYC 7763 64-Core @ 2x 3.242GHz
 /+++//+:`oo+o               /::--:.   RAM: 3378MiB / 7929MiB
 \+/+o+++`o++o               ++////.  
  .++.o+++oo+:`             /dddhhh.  
       .+.o+oo:.          `oddhhhh+   
        \+.++o+o``-````.:ohdhhhhh+    
         `:o+++ `ohhhhhhhhyo++os:     
           .o:`.syhhhhhhh/.oo++o`     
               /osyyyyyyo++ooo+++/    
                   ````` +oo+++o\:    
                          `oo++.      
```

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual Testing

- [X] Test A - Download all files locally and execute docker image. PS: Since im not a webdev i dont know how to write tests for this  type of visual functionality

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
