### PR TITLE
Add namespace to docker container names

### DIFF
--- a/challenges/famous-quotes-lfi/docker-compose.yml
+++ b/challenges/famous-quotes-lfi/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   challenge-famous-quotes-lfi:
-    container_name: challenge-famous-quotes-lfi
+    container_name: scl-famous-quotes-lfi
     stop_grace_period: 0s
     build: ./
     networks:

--- a/challenges/hello-world/docker-compose.yml
+++ b/challenges/hello-world/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   challenge-hello-world:
-    container_name: challenge-hello-world
+    container_name: scl-hello-world
     stop_grace_period: 0s
     build: ./
     networks:

--- a/challenges/intrusion/docker-compose.yml
+++ b/challenges/intrusion/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   intrusion:
-    container_name: intrusion
+    container_name: scl-intrusion
     stop_grace_period: 0s
     build: .
     networks:

--- a/challenges/shockwave-report/docker-compose.yml
+++ b/challenges/shockwave-report/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   shockwave-report:
-    container_name: shockwave-report
+    container_name: scl-shockwave-report
     stop_grace_period: 0s
     build: .
     platform: linux/amd64

--- a/challenges/template/docker-compose.yml
+++ b/challenges/template/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   challenge-template:
-    container_name: challenge-template
+    container_name: scl-challenge-template
     stop_grace_period: 0s
     build: .
     networks:

--- a/challenges/what-is-that-noise/docker-compose.yml
+++ b/challenges/what-is-that-noise/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   what-is-that-noise:
-    container_name: what-is-that-noise
+    container_name: scl-what-is-that-noise
     stop_grace_period: 0s
     build: .
     networks:

--- a/challenges/what-is-the-date/docker-compose.yml
+++ b/challenges/what-is-the-date/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   challenge-what-is-the-date:
-    container_name: challenge-what-is-the-date
+    container_name: scl-what-is-the-date
     build: .
     stop_grace_period: 0s
     networks:

--- a/classes/class02/docker-compose.yml
+++ b/classes/class02/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   class-02-services:
     build: .
     stop_grace_period: 0s
-    container_name: class-02-services
+    container_name: scl-class-02-services
     networks:
       playground-net:
         ipv4_address: 172.20.0.88

--- a/classes/class03/docker-compose.yml
+++ b/classes/class03/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   class-03-ssh:
     build: ssh/
     stop_grace_period: 0s
-    container_name: class-03-ssh
+    container_name: scl-class-03-ssh
     networks:
       playground-net:
         ipv4_address: 172.20.0.90
@@ -12,7 +12,7 @@ services:
   class-03-apache:
     build: apache/
     stop_grace_period: 0s
-    container_name: class-03-apache
+    container_name: scl-class-03-apache
     networks:
       playground-net:
         ipv4_address: 172.20.0.95

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   hackerlab:
     build: ./hackerlab
-    container_name: hackerlab
+    container_name: scl-hackerlab
     hostname: hackerlab
     restart: always
     ports:
@@ -12,7 +12,7 @@ services:
 
   dashboard:
     build: ./dashboard
-    container_name: dashboard
+    container_name: scl-dashboard
     hostname: dashboard
     restart: always
     ports:
@@ -34,7 +34,7 @@ services:
 
   ollama:
     image: ollama/ollama
-    container_name: ollama
+    container_name: scl-ollama
     volumes:
       - ./ollama:/root/.ollama
     restart: always


### PR DESCRIPTION
# Description

Fixes #10 

## Type of change

Reviewed and modified all the docker-compose.yml files for the stratocyberlab, challenges, and classes to introduce a consistent naming and prefix `scl-*`

These are currently the names:

* Main services:
   - container_name: `scl-hackerlab`
   - container_name: `scl-dashboard`
   - container_name: `scl-ollama`
* Classes:
   - container_name: `scl-class-02-services`
   - container_name: `scl-class-03-ssh`
   - container_name: `scl-class-03-apache`
* Challenges 
  - container_name: `scl-famous-quotes-lfi`
  - container_name: `scl-what-is-that-noise`
  - container_name: `scl-challenge-template`
  - container_name: `scl-shockwave-report`
  - container_name: `scl-hello-world`
  - container_name: `scl-what-is-the-date`
  - container_name: `scl-intrusion`

Let me know if you want me to change something else.