### PR TITLE
Add slips light docker to class11

### DIFF
--- a/classes/class11/docker-compose.yml
+++ b/classes/class11/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   class-11-slips:
     image: stratosphereips/slips_light:latest
-    container_name: slips
+    container_name: scl-class-11-slips
     stop_grace_period: 0s
     deploy:
       resources:
@@ -12,7 +12,7 @@ services:
     stdin_open: true
     networks:
       playground-net:
-        ipv4_address: 172.20.0.137
+        ipv4_address: 172.20.0.101
     # a sample pcap to run slips on
     entrypoint: ["/bin/sh", "-c", "mkdir -p /StratosphereLinuxIPS/dataset && curl -L -o /StratosphereLinuxIPS/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && /bin/bash"]
 

--- a/classes/class11/docker-compose.yml
+++ b/classes/class11/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+services:
+  class-11-slips:
+    image: stratosphereips/slips_light:latest
+    container_name: slips
+    stop_grace_period: 0s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.7'
+          memory: 8g
+    stdin_open: true
+    networks:
+      playground-net:
+        ipv4_address: 172.20.0.137
+    # a sample pcap to run slips on
+    entrypoint: ["/bin/sh", "-c", "mkdir -p /StratosphereLinuxIPS/dataset && curl -L -o /StratosphereLinuxIPS/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && /bin/bash"]
+
+networks:
+  playground-net:
+    external: true

--- a/classes/class11/docker-compose.yml
+++ b/classes/class11/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - /bin/sh
       - -c
       - |
-        mkdir -p /StratosphereLinuxIPs/dataset && \
-        curl -L -o /StratosphereLinuxIPs/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && \
+        mkdir -p /StratosphereLinuxIPS/dataset && \
+        curl -L -o /StratosphereLinuxIPS/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && \
         exec /bin/bash
 
 networks:

--- a/classes/class11/docker-compose.yml
+++ b/classes/class11/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   class-11-slips:
     image: stratosphereips/slips_light:latest
-    container_name: scl-class-11-slips
+    container_name: slips
     stop_grace_period: 0s
     deploy:
       resources:
@@ -14,7 +14,13 @@ services:
       playground-net:
         ipv4_address: 172.20.0.101
     # a sample pcap to run slips on
-    entrypoint: ["/bin/sh", "-c", "mkdir -p /StratosphereLinuxIPS/dataset && curl -L -o /StratosphereLinuxIPS/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && /bin/bash"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mkdir -p /StratosphereLinuxIPs/dataset && \
+        curl -L -o /StratosphereLinuxIPs/dataset/reverse_pe_powershell_port80.zip https://github.com/jstrosch/malware-samples/raw/master/training_pcaps/reverse_pe_powershell_port80.zip && \
+        exec /bin/bash
 
 networks:
   playground-net:

--- a/classes/class11/meta.json
+++ b/classes/class11/meta.json
@@ -1,0 +1,7 @@
+{
+    "name": "Class 11 - TODO",
+    "id": "class-11",
+    "description": "TODO",
+    "google_doc_url": "",
+    "yt_recording_url": ""
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,22 +39,23 @@
 
 #### IP allocations
 
-| Network        | IP address    | Used By                                                             | 
-|----------------|---------------|---------------------------------------------------------------------|
-| playground-net | `172.20.0.5`  | Challenge [Hello world](./../challenges/hello-world/)               |
-| playground-net | `172.20.0.10` | Challenge [Famous Quotes LFI](./../challenges/famous-quotes-lfi/)   |
-| playground-net | `172.20.0.30` | Challenge [What's the date?](./../challenges/what-is-the-date/)     |
-| playground-net | `172.20.0.35` | Challenge [What's that noise?](./../challenges/what-is-that-noise/) |
- | playground-net | `172.20.0.39` | Callenge [Shockwave Report](./../challenges/shockwave-report)       |
- | playground-net | `172.20.0.41` | Callenge [Intrusion](./../challenges/intrusion)                     |
- | playground-net | `172.20.0.45` | Callenge [Jump Around](./../challenges/jump-around)                 |
- | playground-net | `172.20.0.47` | Callenge [Jump Around](./../challenges/jump-around)                 |
- | playground-net | `172.20.0.49` | Callenge [Jump Around](./../challenges/jump-around)                 |
- | playground-net | `172.20.0.88` | [Class02](./../classes/class02)                                     |                                                
- | playground-net | `172.20.0.90` | [Class03](./../classes/class03)                                     |                                                
- | playground-net | `172.20.0.95` | [Class03](./../classes/class03)                                     |  
- | playground-net | `172.20.0.98` | [Class06](./../classes/class06)                                     |  
- | playground-net | `172.20.0.99` | [Class06](./../classes/class06)                                     |  
+| Network        | IP address     | Used By                                                             | 
+|----------------|----------------|---------------------------------------------------------------------|
+| playground-net | `172.20.0.5`   | Challenge [Hello world](./../challenges/hello-world/)               |
+| playground-net | `172.20.0.10`  | Challenge [Famous Quotes LFI](./../challenges/famous-quotes-lfi/)   |
+| playground-net | `172.20.0.30`  | Challenge [What's the date?](./../challenges/what-is-the-date/)     |
+| playground-net | `172.20.0.35`  | Challenge [What's that noise?](./../challenges/what-is-that-noise/) |
+ | playground-net | `172.20.0.39`  | Callenge [Shockwave Report](./../challenges/shockwave-report)       |
+ | playground-net | `172.20.0.41`  | Callenge [Intrusion](./../challenges/intrusion)                     |
+ | playground-net | `172.20.0.45`  | Callenge [Jump Around](./../challenges/jump-around)                 |
+ | playground-net | `172.20.0.47`  | Callenge [Jump Around](./../challenges/jump-around)                 |
+ | playground-net | `172.20.0.49`  | Callenge [Jump Around](./../challenges/jump-around)                 |
+ | playground-net | `172.20.0.88`  | [Class02](./../classes/class02)                                     |                                                
+ | playground-net | `172.20.0.90`  | [Class03](./../classes/class03)                                     |                                                
+ | playground-net | `172.20.0.95`  | [Class03](./../classes/class03)                                     |  
+ | playground-net | `172.20.0.98`  | [Class06](./../classes/class06)                                     |  
+ | playground-net | `172.20.0.99`  | [Class06](./../classes/class06)                                     |  
+ | playground-net | `172.20.0.101` | [Class11](./../classes/class11)                                     |  
 
 
 


### PR DESCRIPTION
# Description

The PR contains a docker compose with [slips light version](https://hub.docker.com/repository/docker/stratosphereips/slips_light/general) for class 11.

and one [small pcap]( https://github.com/jstrosch/malware-samples/blob/master/training_pcaps/reverse_pe_powershell_port80.zip) to run slips on.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- **`docker compose up --remove-orphans --build`**
- start class11 from the browser normally
- from your local terminal (not the hackerlab) run **`docker exec -it slips /bin/bash`**
- from the slips container, unzip the test pcap,  **`unzip dataset/reverse_pe_powershell_port80.zip`** with password "infected"
- run slips on the pcap using **`./slips.py -f reverse_pe_powershell_port80.pcap  `**
- or on the interface using **./slips.py -i eth0** 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
