### PR TITLE
Update main.c in class08

### DIFF
--- a/classes/class08/files/stack0/main.c
+++ b/classes/class08/files/stack0/main.c
@@ -5,14 +5,14 @@ int main() {
     volatile int modified;
     char buffer[64];
 
-    modified = 0;
+    modified = 1;
 
     gets(buffer);
 
     if (modified != 0 ) {
-   	 printf("Access granted\n");
-    } else {
    	 printf("Access denied\n");
+    } else {
+   	 printf("Access granted\n");
     }
 
     return 0;


### PR DESCRIPTION
# Description
This change is interesting alternative:
To get access granted, it now uses trick, where EOF bit = 0. So to get "Access granted" as on lecture, it now requires exact length (76 chars, because: Distance = 0x50 - 0x4 = 0x4C bytes = 76 bytes), to make the EOF bit fall on rbp-0x4 aka modified variable.