### PR TITLE
fix(dockerfile): cowrie clone url corrected from http to https

### DIFF
--- a/campaigns/miro/bearific/victim/Dockerfile
+++ b/campaigns/miro/bearific/victim/Dockerfile
@@ -14,7 +14,7 @@ USER cowrie
 RUN <<EOD
 cd
 # install cowrie - steps as per https://docs.cowrie.org/en/latest/INSTALL.html
-git clone http://github.com/cowrie/cowrie
+git clone https://github.com/cowrie/cowrie
 cd cowrie
 python3 -m venv cowrie-env
 . cowrie-env/bin/activate


### PR DESCRIPTION
# Description

This fixes a deployment issue caused by an incorrect URL in the Dockerfile located in `campaigns/miro/bearific/victim/`.

The URL `http://github.com/cowrie/cowrie` on line 17 was causing a connection error during container build. It has been updated to **`https://github.com/cowrie/cowrie`** to ensure a successful connection and allow the repository to be cloned correctly.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

The error was identified during the container build process, which failed to clone the repository due to the incorrect protocol (`http`).

The following test was performed to verify the fix:

1. **Local Build Test:** Attempted to launch Bearific challenge using the updated Dockerfile.
2. **Verification:** The build process completed successfully, confirming that the Git clone step using `https://github.com/cowrie/cowrie` now works correctly, allowing the container to deploy.

**No other functional tests were required** as the change only affected the URL protocol for repository cloning of this particular challenge.


# Checklist:

- [x] My changes generate no new warnings

